### PR TITLE
Fix test failing on some systems because of unexpected localized output

### DIFF
--- a/src/test/java/jsr223/nativeshell/bash/BashScriptEngineTest.java
+++ b/src/test/java/jsr223/nativeshell/bash/BashScriptEngineTest.java
@@ -51,14 +51,9 @@ public class BashScriptEngineTest {
         assertEquals("hello", scriptOutput.toString());
     }
 
-    @Test
+    @Test(expected = ScriptException.class)
     public void evaluate_failing_command() throws Exception {
-        try {
-            scriptEngine.eval("nonexistingcommandwhatsoever");
-            fail();
-        } catch (ScriptException e) {
-            assertTrue(scriptError.toString().contains("nonexistingcommandwhatsoever: command not found\n"));
-        }
+        scriptEngine.eval("nonexistingcommandwhatsoever");
     }
 
     @Test


### PR DESCRIPTION
The test `BashScriptEngineTest#evaluate_failing_command` uses an assertion whose the result may depend of the bash implementation and localization.

The test expects to get `nonexistingcommandwhatsoever: command not found` but `nonexistingcommandwhatsoever : commande introuvable` is returned on my system. 
